### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/main/java/org/mule/extension/socket/api/ImmutableSocketAttributes.java
+++ b/src/main/java/org/mule/extension/socket/api/ImmutableSocketAttributes.java
@@ -7,7 +7,7 @@
 package org.mule.extension.socket.api;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import org.mule.runtime.core.message.BaseAttributes;
+import org.mule.runtime.core.api.message.BaseAttributes;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/mule/extension/socket/api/provider/tcp/TcpListenerProvider.java
+++ b/src/main/java/org/mule/extension/socket/api/provider/tcp/TcpListenerProvider.java
@@ -29,7 +29,7 @@ import org.mule.runtime.api.tls.TlsContextFactory;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.api.lifecycle.InitialisationException;
-import org.mule.runtime.core.config.i18n.CoreMessages;
+import org.mule.runtime.core.api.config.i18n.CoreMessages;
 import org.mule.runtime.extension.api.annotation.Alias;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;


### PR DESCRIPTION
_ Moving classes from org.mule.runtime.core.execution to api/internal
_ Moving classes from org.mule.runtime.core.notification to api/internal
_ Moving more classes from org.mule.runtime.core.management.stats to api/internal
_ Moving more classes from org.mule.runtime.core.config to api/internal