### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.mule.tests.plugin</groupId>
             <artifactId>mule-tests-component-plugin</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>${mule.version}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
             <version>${assertJVersion}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <classifier>mule-plugin</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/org/mule/extension/socket/api/source/SocketListener.java
+++ b/src/main/java/org/mule/extension/socket/api/source/SocketListener.java
@@ -22,7 +22,7 @@ import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.construct.FlowConstructAware;
 import org.mule.runtime.core.api.scheduler.SchedulerService;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 import org.mule.runtime.extension.api.annotation.dsl.xml.XmlHints;
 import org.mule.runtime.extension.api.annotation.execution.OnError;
 import org.mule.runtime.extension.api.annotation.execution.OnSuccess;

--- a/src/test/java/org/mule/extension/socket/CustomProtocolTestCase.java
+++ b/src/test/java/org/mule/extension/socket/CustomProtocolTestCase.java
@@ -7,7 +7,7 @@
 package org.mule.extension.socket;
 
 import static org.hamcrest.Matchers.instanceOf;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import org.junit.Test;
 

--- a/src/test/java/org/mule/extension/socket/TcpConnectionTimeoutTestCase.java
+++ b/src/test/java/org/mule/extension/socket/TcpConnectionTimeoutTestCase.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;

--- a/src/test/java/org/mule/extension/socket/TcpReadingTimeoutTestCase.java
+++ b/src/test/java/org/mule/extension/socket/TcpReadingTimeoutTestCase.java
@@ -7,7 +7,7 @@
 package org.mule.extension.socket;
 
 import static org.hamcrest.Matchers.instanceOf;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import java.net.SocketTimeoutException;
 

--- a/src/test/java/org/mule/extension/socket/UdpTimeoutTestCase.java
+++ b/src/test/java/org/mule/extension/socket/UdpTimeoutTestCase.java
@@ -8,7 +8,7 @@ package org.mule.extension.socket;
 
 import static org.hamcrest.Matchers.instanceOf;
 import org.mule.extension.socket.api.exceptions.ReadingTimeoutException;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import org.junit.Test;
 

--- a/src/test/java/org/mule/extension/socket/protocol/LengthProtocolTestCase.java
+++ b/src/test/java/org/mule/extension/socket/protocol/LengthProtocolTestCase.java
@@ -9,7 +9,7 @@ package org.mule.extension.socket.protocol;
 import static org.hamcrest.Matchers.instanceOf;
 import org.mule.extension.socket.SocketExtensionTestCase;
 import org.mule.extension.socket.api.exceptions.LengthExceededException;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import org.junit.Test;
 


### PR DESCRIPTION
MULE-10370: Remove custom-exception-strategy element

_ Moving classes from org.mule.runtime.core.extension to api/internal
_ Temporarily exporting org.mule.runtime.core.internal.extension (because MULE-12427)
_ Adding test:exception-strategy for tests to replace mule:custom-exception-strategy
_ Removing mule:custom-exception-strategy element