### PR TITLE
MULE-18516: TCP Connector is only reading the first packet of a multi…

### DIFF
--- a/src/main/java/org/mule/extension/socket/api/connection/tcp/protocol/XmlMessageProtocol.java
+++ b/src/main/java/org/mule/extension/socket/api/connection/tcp/protocol/XmlMessageProtocol.java
@@ -134,6 +134,6 @@ public class XmlMessageProtocol extends AbstractByteProtocol {
    * @see XmlMessageEOFProtocol
    */
   protected boolean isRepeat(int patternIndex, int len, int available) {
-    return patternIndex < 0 && len == READ_BUFFER_SIZE && available > 0;
+    return patternIndex < 0 && available > 0;
   }
 }

--- a/src/test/java/org/mule/extension/socket/protocol/XmlMessageProtocolTestCase.java
+++ b/src/test/java/org/mule/extension/socket/protocol/XmlMessageProtocolTestCase.java
@@ -114,8 +114,7 @@ public class XmlMessageProtocolTestCase extends AbstractMuleTestCase {
 
     InputStream result = read(bais);
     assertNotNull(result);
-    // only get the first character! use XmlMessageEOFProtocol instead
-    assertEquals(msgData.substring(0, 1), IOUtils.toString(result));
+    assertEquals(msgData, IOUtils.toString(result));
   }
 
 }


### PR DESCRIPTION
…packet message, truncating the payload when using xml-protocol

There was a criteria for deciding whether to continue reading from the input stream or not that relied on the read method using the whole buffer to the last byte. That is not guaranteed by the read method of InputStream. If the whole buffer was not used there might still be data left to read.

Fixed the isRepeat method and the assertions in the test that reproduced the behaviour. If the input stream is "slow" it should still read the data completely.