### PR TITLE
SOCON-4: Include cause of class load failure. (#110)

### DIFF
--- a/src/main/java/org/mule/extension/socket/api/connection/tcp/protocol/CustomProtocol.java
+++ b/src/main/java/org/mule/extension/socket/api/connection/tcp/protocol/CustomProtocol.java
@@ -58,7 +58,7 @@ public class CustomProtocol implements TcpProtocol {
     try {
       return (TcpProtocol) ClassUtils.instantiateClass(clazz);
     } catch (Exception e) {
-      throw new RuntimeException(format("Could not load class '%s'", clazz));
+      throw new RuntimeException(format("Could not load class '%s'", clazz), e);
     }
   }
 


### PR DESCRIPTION
Trying to resolve why a custom protocol implementation is giving "Could not load class", without seeing the exception, is really painful.

Co-authored-by: Ryan Slack <ryan.slack@bitsinglass.com>
(cherry picked from commit 9a51054236b40737f5b509088cc935ac7e0ae4c1)