### PR TITLE
SOCON-5: renovate settings for ignoring monthly builds

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,16 @@
 {
   "extends": [
     "config:base"
+  ],
+  "branchPrefix": "renovate-",
+  "prHourlyLimit": 1,
+  "prConcurrentLimit": 10,
+  "schedule": [
+    "after 8pm and before 8am on every weekday",
+    "every weekend"
+  ],
+  "timezone": "America/Argentina/Buenos_Aires",
+  "ignoreDeps": [
+    "org.mule.extensions:mule-core-modules-parent"
   ]
 }


### PR DESCRIPTION
Renovate settings for ignoring monthly builds